### PR TITLE
Update README.md to fix install instructions for KDiff3

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,10 +77,12 @@ These tools can be linked to Git by editing the `diff`, `merge`, `difftool`, and
 
 ```
 git config --global merge.tool kdiff3
-git config --global mergetool.kdiff3.path "C:/Program Files/KDiff3/kdiff3.exe"
+git config --global mergetool.kdiff3.cmd "\"C:/Program Files/Kdiff3/kdiff3\" --L1 \"\$MERGED (Base)\" --L2 \"\$MERGED (Local)\" --L3 \"\$MERGED (Remote)\" -o \"\$MERGED\" \"\$BASE\" \"\$LOCAL\" \"\$REMOTE\""
 git config --global diff.guitool kdiff3
 git config --global difftool.kdiff3.path "C:/Program Files/KDiff3/kdiff3.exe"
 ```
+
+Note that the path may need to be updated based on the install location of Kdiff3.
 
 # Severson Group Git Usage
 This section provide guidance for using Git on Severson Group projects. These are typical or recommended guidelines. Individual projects may have specific needs and deviate from these guidelines. _That is perfectly fine_, but should be documented within that project.


### PR DESCRIPTION
Fix instructions for configuring Kdiff3. The merge feature did not work with the previous instructions.