### PR TITLE
Update default install path of KDiff3

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,9 +107,9 @@ These tools can be linked to Git by editing the `diff`, `merge`, `difftool`, and
 
 ```
 git config --global merge.tool kdiff3
-git config --global mergetool.kdiff3.cmd "\"C:/Program Files/Kdiff3/kdiff3\" --L1 \"\$MERGED (Base)\" --L2 \"\$MERGED (Local)\" --L3 \"\$MERGED (Remote)\" -o \"\$MERGED\" \"\$BASE\" \"\$LOCAL\" \"\$REMOTE\""
+git config --global mergetool.kdiff3.cmd "\"C:/Program Files/Kdiff3/bin/kdiff3\" --L1 \"\$MERGED (Base)\" --L2 \"\$MERGED (Local)\" --L3 \"\$MERGED (Remote)\" -o \"\$MERGED\" \"\$BASE\" \"\$LOCAL\" \"\$REMOTE\""
 git config --global diff.guitool kdiff3
-git config --global difftool.kdiff3.cmd "\"C:/Program Files/Kdiff3/kdiff3\" \$LOCAL \$REMOTE"
+git config --global difftool.kdiff3.cmd "\"C:/Program Files/Kdiff3/bin/kdiff3\" \$LOCAL \$REMOTE"
 ```
 
 Note that the path may need to be updated based on the install location of Kdiff3.


### PR DESCRIPTION
This PR updates the KDiff3 install instructions with the new default install path for the latest version of KDiff3. Previous versions of KDiff3 placed the executable in the root of the application folder, while the latest version places the executable into the bin folder inside the application folder.